### PR TITLE
Syntax fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,7 +108,7 @@ Vagrant.configure(2) do |config|
     pg_slave_config.vm.provision :shell, path: "provision_postgres.sh"
     # target user and postgres has to be in place before setting up ssh
     pg_slave_config.vm.provision :shell, path: "ssh_passwordless.sh" 
-    pg_slave_config.vm.provision :shell, path: "provision_slave.sh" args: "pg-master"
+    pg_slave_config.vm.provision :shell, path: "provision_slave.sh", args: "pg-master"
 
   end
 


### PR DESCRIPTION
```
➜  pg_cluster_demo git:(master) vagrant up pg_master pg_slave balancer
There is a syntax error in the following Vagrantfile. The syntax error
message is reproduced below for convenience:

/Users/aliona/Github/pg_cluster_demo/Vagrantfile:111: syntax error, unexpected tIDENTIFIER, expecting keyword_end
...path: "provision_slave.sh" args: "pg-master"
...                               ^
```